### PR TITLE
Fixed imports from statblock.ts for case-sensitive filesystems

### DIFF
--- a/src/scripts/extractstatblock.ts
+++ b/src/scripts/extractstatblock.ts
@@ -1,5 +1,5 @@
 import cash, { Cash } from "cash-dom";
-import { StatBlock, AbilityScores, NameAndContent } from "./StatBlock";
+import { StatBlock, AbilityScores, NameAndContent } from "./statblock";
 
 export const extractStatBlock = () => {
   const doc = cash(document);

--- a/src/scripts/popup.tsx
+++ b/src/scripts/popup.tsx
@@ -1,5 +1,5 @@
 import ext from "./utils/ext";
-import { StatBlock } from "./StatBlock";
+import { StatBlock } from "./statblock";
 import { ScrapeStatBlockAction } from "./actions";
 import { h, render } from "preact";
 import { HelpText } from "./HelpText";


### PR DESCRIPTION
extractstatblock.ts and popup.tsx were importing StatBlock from "./StatBlock", which was failing since the filename of statblock.ts is all lowercase.

Updated both files to import from "./statblock" instead.