### PR TITLE
half-proficiency, expertise pull on character sheet import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "send-to-improved-initiative",
-  "version": "0.1.2",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/scripts/convertCharacterSheetToStatBlock.ts
+++ b/src/scripts/convertCharacterSheetToStatBlock.ts
@@ -168,7 +168,7 @@ function getSaves(element: Cash) {
 
 function getSkills(element: Cash) {
   return element
-    .find(`[data-original-title="Proficiency"]`)
+    .find(`[data-original-title="Proficiency"], [data-original-title="Half Proficiency"], [data-original-title="Expertise"]`)
     .parents(".ct-skills__item")
     .get()
     .map(el => {


### PR DESCRIPTION
fixed formatting on convertCharacterSheetToStatBlock to correctly pull in half-proficiency and expertise. Tested via firefox through temp add-on loader