### PR TITLE
Add Link to Source in Description/Fix options display/Address #8

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "__MSG_appName__",
-  "version": "0.3.2",
+  "version": "0.4.1",
   "manifest_version": 2,
   "description": "__MSG_appDescription__",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "send-to-improved-initiative",
-  "version": "0.3.2",
+  "version": "0.4.1",
   "description": "A cross browser extension that imports D&D Beyond StatBlocks into Improved Initiative",
   "repository": {
     "url": "https://github.com/cynicaloptimist/send-to-improved-initiative"
@@ -21,7 +21,8 @@
   },
   "author": "Evan Bailey <improvedinitiativedev@gmail.com> (https://github.com/cynicaloptimist)",
   "contributors": [
-    "Bharani <bharani91@gmail.com> (https://github.com/bharani91)"
+    "Bharani <bharani91@gmail.com> (https://github.com/bharani91)",
+    "twloveduck <?> (https://github.com/twloveduck)"
   ],
   "devDependencies": {
     "@types/chrome": "0.0.88",

--- a/src/scripts/background.ts
+++ b/src/scripts/background.ts
@@ -5,6 +5,7 @@ const codec = require("json-url")("lzma");
 
 const runtime: typeof chrome.runtime = ext.runtime;
 const tabs: typeof chrome.tabs = ext.tabs;
+var CurrentTabId = undefined;
 
 storage.get(Object.values(Options), values => {
   for (const option in OptionDefaults) {
@@ -16,15 +17,45 @@ storage.get(Object.values(Options), values => {
   }
 });
 
-runtime.onMessage.addListener(function(request, sender, sendResponse) {
+function newIITab(url: string) {
+  tabs.create({ url: url }, (tab) => {
+    CurrentTabId = tab.id;
+    console.log('New II tab id: ', CurrentTabId)
+  });
+}
+
+// Handles if the II tab is closed.
+tabs.onRemoved.addListener((tabId: number, remInfo: object) => {
+  if(CurrentTabId === tabId)
+    CurrentTabId = undefined
+})
+
+runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request.action === "perform-save") {
     storage.get(Options.TargetUrl, async values => {
       const compressed = await codec.compress(
         JSON.stringify(request.importedStatBlock)
       );
-      tabs.create({
-        url: values[Options.TargetUrl] + "?s=" + encodeURIComponent(compressed)
-      });
+
+      let iiUrl = values[Options.TargetUrl] + "?s=" + encodeURIComponent(compressed)
+      if (CurrentTabId) {
+        try {
+          tabs.update(CurrentTabId, { url: iiUrl, active: true }, tab => {
+            if (!tab || tab.id === tabs.TAB_ID_NONE) {
+              console.error('Did not find tab')
+              newIITab(iiUrl)
+            }
+            else
+              console.log('Changed the existing tab url.')
+          })
+        }
+        catch (error) {
+          console.log('Err while getting tab.', error)
+        }
+      }
+      else
+        newIITab(iiUrl)
+
       sendResponse({ action: "saved" });
     });
   }

--- a/src/scripts/convertCharacterSheetToStatBlock.ts
+++ b/src/scripts/convertCharacterSheetToStatBlock.ts
@@ -47,7 +47,7 @@ export const convertCharacterSheetToStatBlock = (options: AllOptions) => {
     Reactions: [],
     LegendaryActions: [],
     ImageURL: getImageUrl(characterSheetElement),
-    Description: options["include-link"] ? `[Link to DNDB Character](${document.location.href})` : "",
+    Description: options["include-link"] === 'on' ? `[Link to DNDB Character](${document.location.href})` : "",
     Player: "player",
   };
   return statBlock;

--- a/src/scripts/convertCharacterSheetToStatBlock.ts
+++ b/src/scripts/convertCharacterSheetToStatBlock.ts
@@ -9,18 +9,20 @@ export const convertCharacterSheetToStatBlock = (options: AllOptions) => {
   const statBlock: Partial<StatBlock> = {
     Source: "",
     Name: characterSheetElement
-      .find(prefix("character-tidbits__name"))
+      .find(prefix("character-name"))
       .text()
       .trim(),
     Type: characterSheetElement
-      .find(prefix("character-tidbits__race"))
+      .find(prefix("character-summary__race"))
       .text()
       .trim(),
     HP: getHitPoints(characterSheetElement),
     AC: getArmorClass(characterSheetElement),
     Abilities: getAbilities(characterSheetElement),
     Speed: [characterSheetElement.find(prefix("speed-box__box-value")).text()],
-    // InitiativeModifier?: number,
+    InitiativeModifier: Number(characterSheetElement.find(prefix('initiative-box__value'))
+      .text()
+      .trim().replace('+', '')),
     // InitiativeSpecialRoll?: "advantage" | "disadvantage" | "take-ten",
     // InitiativeAdvantage?: boolean,
     DamageVulnerabilities: getDefenses(characterSheetElement, "Vulnerability"),
@@ -45,7 +47,7 @@ export const convertCharacterSheetToStatBlock = (options: AllOptions) => {
     Reactions: [],
     LegendaryActions: [],
     ImageURL: getImageUrl(characterSheetElement),
-    Description: "",
+    Description: options["include-link"] ? `[Link to DNDB Character](${document.location.href})` : "",
     Player: "player",
   };
   return statBlock;

--- a/src/scripts/extractstatblock.ts
+++ b/src/scripts/extractstatblock.ts
@@ -51,14 +51,7 @@ export const extractStatBlock = (options: AllOptions) => {
     Reactions: getPowers(statBlockElement, "Reactions"),
     LegendaryActions: getPowers(statBlockElement, "Legendary Actions"),
     ImageURL: doc.find(".details-aside .image a").attr("href") || "",
-    Description:
-      options[Options.IncludeDescription] == "on"
-        ? doc
-            .find(".mon-details__description-block-content")
-            .text()
-            .trim()
-            .replace(/([^\n])\n([^\n])/gm, "$1\n\n$2") //replace single line breaks with double
-        : "",
+    Description: getDescription(doc, options), // twloveduck 2021.10.15 -- Moved to separate function.
     Player: ""
   };
 
@@ -76,6 +69,29 @@ function getSource(element: Cash, includePageNumber: boolean) {
   } else {
     return source.split(",")[0];
   }
+}
+
+/**
+ * Parse the HTML element to extract the description text.
+ * 
+ * twloveduck 2021.10.14 -- Moved from inline in the extract to a separate function to add a link back to DDB in the description.
+ * @param {Cash} doc The document element to parse for the description content.
+ * @param {AllOptions} options The user's chosen options.
+ * @returns {string} The monster description string. 
+ */
+function getDescription(doc: Cash, options: AllOptions) {
+  let retVal = "";
+  if (options[Options.IncludeDescription] === "on") {
+    retVal = doc.find(".mon-details__description-block-content")
+      .text()
+      .trim()
+      .replace(/([^\n])\n([^\n])/gm, "$1\n\n$2")//replace single line breaks with double
+  }
+  // twloveduck 2021.10.14 -- If the user has set the option then include a link back to DDB in the description.
+  if (options["include-link"] === "on")
+    retVal += `\n\n[Link to DNDB Monster](${document.location.href})`
+
+  return retVal.trim()
 }
 
 function getName(element: Cash) {

--- a/src/scripts/options.tsx
+++ b/src/scripts/options.tsx
@@ -1,7 +1,8 @@
 export enum Options {
   TargetUrl = "target-url",
   IncludePageNumberWithSource = "include-page-number-with-source",
-  IncludeDescription = "include-description"
+  IncludeDescription = "include-description",
+  IncludeLink = "include-link"
 }
 
 export type AllOptions = Record<Options, string>;
@@ -9,5 +10,6 @@ export type AllOptions = Record<Options, string>;
 export const OptionDefaults: AllOptions = {
   [Options.TargetUrl]: "https://www.improved-initiative.com/e/",
   [Options.IncludePageNumberWithSource]: "on",
-  [Options.IncludeDescription]: "on"
+  [Options.IncludeDescription]: "on",
+  [Options.IncludeLink]: "on"
 };

--- a/src/scripts/optionseditor.tsx
+++ b/src/scripts/optionseditor.tsx
@@ -20,42 +20,51 @@ function OptionsEditor(props: { currentOptions: AllOptions }) {
         </div>
       </div>
       <section class="content">
-        <div class="grid">
+        <div class="grid" id="main">
           <div class="unit whole center-on-mobiles">
             <div class="option">
-              <label>
-                <input
-                  type="checkbox"
-                  checked={
-                    props.currentOptions[Options.IncludeDescription] == "on"
-                  }
-                  onChange={UpdateCheckbox(Options.IncludeDescription)}
-                />{" "}
-                Include description
-              </label>
-            </div>
-            <div class="option">
-              <label>
-                <input
-                  type="checkbox"
-                  checked={
-                    props.currentOptions[Options.IncludePageNumberWithSource] ==
-                    "on"
-                  }
-                  onChange={UpdateCheckbox(Options.IncludePageNumberWithSource)}
-                />{" "}
-                Include page number in source
-              </label>
-            </div>
-            <div class="option">
-              <h5>Target URL</h5>
-              <input
-                class="js-text target-url"
-                type="text"
-                name="target-url"
-                value={props.currentOptions[Options.TargetUrl]}
-                onChange={UpdateText(Options.TargetUrl)}
+              
+            <input type="checkbox" id="Include-Description" checked={
+              props.currentOptions[Options.IncludeDescription] === "on"
+            }
+              onChange={UpdateCheckbox(Options.IncludeDescription)} />
+            <label for="Include-Description">Include description</label>
+          </div>
+          <div class="option">
+            <input
+              type="checkbox"
+              id="Options.IncludePageNumberWithSource"
+              checked={
+                props.currentOptions[Options.IncludePageNumberWithSource] === "on"
+              }
+              onChange={UpdateCheckbox(Options.IncludePageNumberWithSource)}
+            />
+            <label for="Options.IncludePageNumberWithSource">Include page number in source</label>
+          </div>
+          <div class="option">
+            <input 
+              type="checkbox" 
+              id="Options.IncludeLink"
+              checked={
+                props.currentOptions[Options.IncludeLink] === "on"
+              }
+              onChange={UpdateCheckbox(Options.IncludeLink)}
+              title="Includes a link back to the source URL at the end of the description block."
               />
+            <label for="Options.IncludeLink">Include Link to Source in Description</label>
+          </div>
+          <div class="option">
+            <label for="Options.TargetUrl">Target URL</label>
+            <input
+              id="Options.TargetUrl"
+              class="js-text target-url"
+              type="text"
+              name="target-url"
+              value={props.currentOptions[Options.TargetUrl]}
+              onChange={UpdateText(Options.TargetUrl)}
+              placeholder="https://www.improved-initiative.com/e/"
+              title="The URL that the data is sent to. Typically https://www.improved-initiative.com/e/"
+            />
             </div>
           </div>
         </div>

--- a/src/scripts/popup.tsx
+++ b/src/scripts/popup.tsx
@@ -72,7 +72,7 @@ function Importer(props: { importedStatBlock?: StatBlock }) {
 }
 
 var renderPortraitWarningIfNeeded = (data: StatBlock) => {
-  if (data.ImageURL.length > 0) {
+  if (data && data.ImageURL && data.ImageURL.length > 0) {
     return "";
   }
   return (

--- a/src/styles/modules/_variables.scss
+++ b/src/styles/modules/_variables.scss
@@ -15,3 +15,4 @@ $line-height-base:                    1.5;
 $headings-font-weight:                500;
 $headings-line-height:                1.1;
 $headings-color:                      $text-color;
+$border-radius:                       10px;

--- a/src/styles/options.scss
+++ b/src/styles/options.scss
@@ -16,8 +16,24 @@
 
 .content {
   min-height: 300px;
+  #main {
+    background-color: transparentize($color: $brand-primary, $amount: 0.8);
+    border-radius: $border-radius;
+  }
 }
 
 .target-url {
   width: 100%;
+  border-radius: $border-radius;
+  padding: $border-radius/2;
+}
+
+.option {
+  label {
+    font-weight: bold;
+  }
+  input[type], [type=checkbox] {
+    appearance: auto;
+    margin: 5px;
+  }
 }


### PR DESCRIPTION
I don't know if you are still using this repo for development (it seems that the most recent released version isn't reflected in the code). Regardless I figured I wanted to address the reuse of tabs issue (#8) and add links back to the source in the description so this pull does that. Additionally the options are not currently being displayed in chrome (94.0.4606.81 (Official Build) (64-bit)) at all so I addressed that issue and spruced up the options page (including an option to not have a link back to the source in the description).

## Addressing #8 
All changes for this are isolated in src/scripts/background.ts mostly [lines 20-31](https://github.com/twloveduck/send-to-improved-initiative/blob/5b52f422dbf7153657fce22377cdb5809f90dc57/src/scripts/background.ts#L20-L31) and [41-57](https://github.com/twloveduck/send-to-improved-initiative/blob/5b52f422dbf7153657fce22377cdb5809f90dc57/src/scripts/background.ts#L41-L57)

## Links back to source
These edits add a link in the description back to the source url as in the image at the bottom.
![Screenshot (10)](https://user-images.githubusercontent.com/10177720/137813007-12b7caff-c7d3-4bb8-8f62-61e2ef0aa032.png)

For monsters the edits are [here](https://github.com/twloveduck/send-to-improved-initiative/blob/f17db31f16033f4f46e03581472bbb0ce925c9c0/src/scripts/extractstatblock.ts#L74-L95), and [here](https://github.com/twloveduck/send-to-improved-initiative/blob/f17db31f16033f4f46e03581472bbb0ce925c9c0/src/scripts/extractstatblock.ts#L54)

For characters the edit is [here](https://github.com/twloveduck/send-to-improved-initiative/blob/5b52f422dbf7153657fce22377cdb5809f90dc57/src/scripts/convertCharacterSheetToStatBlock.ts#L50)

And both share options added in [optionseditor.tsx](https://github.com/twloveduck/send-to-improved-initiative/blob/5b52f422dbf7153657fce22377cdb5809f90dc57/src/scripts/optionseditor.tsx) and [options.tsx](https://github.com/twloveduck/send-to-improved-initiative/blob/5b52f422dbf7153657fce22377cdb5809f90dc57/src/scripts/options.tsx).

I also snuck in a limited parse of character initiative modifier [here at line 23](https://github.com/twloveduck/send-to-improved-initiative/blob/5b52f422dbf7153657fce22377cdb5809f90dc57/src/scripts/convertCharacterSheetToStatBlock.ts#L23). It won't grab advantage, but it at least grabs the value.

## Options display on chrome.
Almost all changes in 5b52f422dbf7153657fce22377cdb5809f90dc57 related to displaying the checkbox options in chrome/sprucing up.
This is what it looked like before for the current chrome version.
![Screenshot (13)](https://user-images.githubusercontent.com/10177720/137814190-ac8b954d-0c59-4fd6-a5e9-f8a62152fa3f.png)
Versus the changes now
![Screenshot (14)](https://user-images.githubusercontent.com/10177720/137814534-b297d979-2228-4bed-96aa-3259fc4321fd.png)
 
# Testing & TODOs
I have tested my changes in chrome well. It doesn't matter if the user closes the import tab - the re-use code recognizes if the tab is still there and reuses it if so, creates another if not. The links work fine, and honor the option selected in the options dialog fine. I haven't however tested this code in either opera or firefox. So you may want to check those browsers before accepting the pull.

Let me know if you have any questions, concerns, etc. Thanks for the great software!

**tuck** [Patreon supporter](https://www.patreon.com/user?u=48293539)